### PR TITLE
UX Flow #1 to register process

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import ProtectedRoutes from "./components/ProtectedRoutes";
 import Dashboard from "./pages/dashboard/Dashboard";
 import Messages from "./pages/messages/Messages";
 import Matches from "./pages/matches/Matches";
+import CurrentCourses from "./pages/courses/CurrentCourses";
 
 const router = createBrowserRouter([
   {
@@ -24,25 +25,29 @@ const router = createBrowserRouter([
     element: <div>About</div>,
   },
   {
-    path: "register",
+    path: "/register",
     element: <RegisterPage />,
+  },
+  {
+    path: "/register/current-courses",
+    element: <CurrentCourses />,
   },
   {
     path: "login",
     element: <LoginPage />,
   },
-  
+
   {
     path: "dashboard",
     element: <Dashboard />,
   },
   {
     path: "matches",
-    element: <Matches />
+    element: <Matches />,
   },
   {
     path: "messages",
-    element: <Messages />
+    element: <Messages />,
   },
 ]);
 

--- a/frontend/src/components/BackButton.tsx
+++ b/frontend/src/components/BackButton.tsx
@@ -1,14 +1,16 @@
 import BackIcon from "../assets/backIcon.png";
 
-const BackButton = () => {
+interface BackButtonProps {
+  onClickHandler: () => void;
+}
+
+const BackButton = ({ onClickHandler }: BackButtonProps) => {
   return (
-    <button className="w-11 h-11 inline-flex items-center justify-center rounded-full bg-secondary-bg-500"
+    <button
+      className="w-11 h-11 inline-flex items-center justify-center rounded-full bg-secondary-bg-500"
+      onClick={onClickHandler}
     >
-      <img
-        src={BackIcon}
-        alt="Back"
-        className="w-3/5 h-2/5 filter invert"
-      />
+      <img src={BackIcon} alt="Back" className="w-3/5 h-2/5 filter invert" />
     </button>
   );
 };

--- a/frontend/src/components/CourseButton.tsx
+++ b/frontend/src/components/CourseButton.tsx
@@ -9,13 +9,21 @@ import { useState } from "react";
 interface CourseButtonProps {
   course: string;
   disabled: boolean;
+  onClickHandler: () => void;
+  initiallyClicked?: boolean;
 }
 
-const CourseButton: React.FC<CourseButtonProps> = ({ course, disabled }) => {
-  const [isClicked, setIsClicked] = useState(false);
+const CourseButton: React.FC<CourseButtonProps> = ({
+  course,
+  disabled,
+  onClickHandler,
+  initiallyClicked = false,
+}) => {
+  const [isClicked, setIsClicked] = useState(initiallyClicked);
 
   const handleClick = () => {
     if (!disabled) {
+      onClickHandler();
       setIsClicked((prevState) => !prevState);
     }
   };
@@ -23,12 +31,12 @@ const CourseButton: React.FC<CourseButtonProps> = ({ course, disabled }) => {
   const dynamicStyle = disabled
     ? "text-tertiary-500 bg-tertiary-bg-500 border-tertiary-bg-500"
     : isClicked
-      ? "bg-secondary-bg-500 border-secondary-bg-600 text-white"
-      : "text-secondary-bg-500 bg-white hover:bg-secondary-bg-500 hover:text-white";
+    ? "bg-secondary-bg-500 text-white"
+    : "text-secondary-bg-500 bg-white";
 
   return (
     <button
-      className='rounded-full  transition-all duration-250  px-6 py-2  border-2 border-secondary-bg-500 outline-none ${dynamicStyle}'
+      className={`font-semibold rounded-full transition-all duration-150 px-12 py-[10px] border-3 border-secondary-bg-500 outline-none ${dynamicStyle}`}
       onClick={!disabled ? handleClick : undefined}
     >
       {course}

--- a/frontend/src/components/CustomButton.tsx
+++ b/frontend/src/components/CustomButton.tsx
@@ -2,13 +2,20 @@ type CustomButtonProps = {
   children: React.ReactNode;
   disabled: boolean;
   type: "button" | "submit" | "reset";
+  onClick?: () => void;
 };
 
-const CustomButton = ({ children, disabled, type }: CustomButtonProps) => {
+const CustomButton = ({
+  children,
+  disabled,
+  type,
+  onClick,
+}: CustomButtonProps) => {
   return (
     <button
       disabled={disabled}
       type={type}
+      onClick={onClick}
       className="my-4 px-5 py-2 rounded-md bg-primary-bg-500 text-primary-500 font-extrabold text-2xl"
     >
       {children}

--- a/frontend/src/components/Input.tsx
+++ b/frontend/src/components/Input.tsx
@@ -4,9 +4,15 @@ type InputProps = {
   placeholder: string;
   type: string;
   forwardedRef: RefObject<HTMLInputElement>;
+  initialValue?: string;
 };
 
-const Input = ({ placeholder, type, forwardedRef }: InputProps) => {
+const Input = ({
+  placeholder,
+  type,
+  forwardedRef,
+  initialValue,
+}: InputProps) => {
   return (
     <input
       className="rounded-md border-tertiary-200 border bg-transparent outline-none
@@ -17,6 +23,7 @@ const Input = ({ placeholder, type, forwardedRef }: InputProps) => {
       placeholder={placeholder}
       ref={forwardedRef}
       autoComplete={type === "password" ? "on" : "off"}
+      value={initialValue}
     />
   );
 };

--- a/frontend/src/components/SearchBar.tsx
+++ b/frontend/src/components/SearchBar.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+
+interface SearchBarProps {
+  handleChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+}
+
+const SearchBar = ({ handleChange }: SearchBarProps) => {
+  return (
+    <input
+      type="text"
+      placeholder="Search for a course"
+      className="w-full placeholder:text-center text-center py-2 bg-gray-300 rounded-full outline-none placeholder:text-gray-700"
+      onChange={handleChange}
+    />
+  );
+};
+
+export default SearchBar;

--- a/frontend/src/pages/courses/CurrentCourses.tsx
+++ b/frontend/src/pages/courses/CurrentCourses.tsx
@@ -1,0 +1,101 @@
+import React, { useCallback, useMemo, useState } from "react";
+import ProgressBar from "../../components/ProgressBar";
+import UNSWipeIcon from "../../assets/UNSWipe-cat.png";
+import CustomButton from "../../components/CustomButton";
+import { COURSES_LIST } from "../../utils/constants";
+import CourseButton from "../../components/CourseButton";
+import SearchBar from "../../components/SearchBar";
+import { useNavigate } from "react-router-dom";
+import BackButton from "../../components/BackButton";
+
+const CurrentCourses = () => {
+  const [courseList, setCourseList] = useState<string[]>(COURSES_LIST);
+  const [selectedCourses, setSelectedCourses] = useState<string[]>(
+    JSON.parse(localStorage.getItem("selectedCurrentCourses") || "[]")
+  );
+  const navigate = useNavigate();
+
+  const handleSearchCourse = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const searchValue = e.target.value;
+    const filteredCourses = COURSES_LIST.filter((course) =>
+      course.toLowerCase().includes(searchValue.toLowerCase())
+    );
+    setCourseList(filteredCourses);
+  };
+
+  const handleSelectCourse = useCallback(
+    (course: string) => {
+      if (selectedCourses.includes(course)) {
+        setSelectedCourses((prevState) =>
+          prevState.filter((selectedCourse) => selectedCourse !== course)
+        );
+      } else {
+        setSelectedCourses((prevState) => [...prevState, course]);
+      }
+    },
+    [selectedCourses]
+  );
+
+  const handleGoNext = () => {
+    localStorage.setItem(
+      "selectedCurrentCourses",
+      JSON.stringify(selectedCourses)
+    );
+    navigate("/register/future-courses");
+  };
+
+  const handleGoBack = () => {
+    localStorage.setItem(
+      "selectedCurrentCourses",
+      JSON.stringify(selectedCourses)
+    );
+    navigate("/register");
+  };
+
+  const courseButtonList = useMemo(() => {
+    return courseList.map((course) => (
+      <div className="my-3" key={course}>
+        <CourseButton
+          key={course}
+          disabled={false}
+          course={course}
+          onClickHandler={() => handleSelectCourse(course)}
+          initiallyClicked={selectedCourses.includes(course)}
+        />
+      </div>
+    ));
+  }, [courseList, handleSelectCourse, selectedCourses]);
+
+  return (
+    <>
+      <div className="absolute top-5 left-5">
+        <BackButton onClickHandler={handleGoBack} />
+      </div>
+      <div className="h-svh w-svw p-3 flex flex-col justify-center items-center">
+        <img src={UNSWipeIcon} alt="UNSWipe Icon" className="h-28" />
+        <ProgressBar progress={20} />
+        <div className="w-full m-3">
+          <h1 className="text-secondary-bg-600 font-black text-4xl">
+            Courses?
+          </h1>
+          <div className="max-w-[90%]">
+            <p className="inline font-extralight text-sm">
+              Select all the courses you are{" "}
+            </p>
+            <p className="inline text-red-600 font-black">⚠️ CURRENTLY ⚠️</p>
+            <p className="inline font-extralight text-sm"> doing.</p>
+          </div>
+        </div>
+        <SearchBar handleChange={handleSearchCourse} />
+        <div className="w-full h-[90%] m-1 overflow-auto flex flex-wrap flex-row justify-around item-center">
+          {courseButtonList}
+        </div>
+        <CustomButton disabled={false} type="button" onClick={handleGoNext}>
+          NEXT
+        </CustomButton>
+      </div>
+    </>
+  );
+};
+
+export default CurrentCourses;

--- a/frontend/src/pages/login/Login.tsx
+++ b/frontend/src/pages/login/Login.tsx
@@ -1,6 +1,6 @@
 import Input from "../../components/Input";
 import Heading from "../../components/Heading";
-import { Link, Navigate, useNavigate } from "react-router-dom";
+import { Link, Navigate } from "react-router-dom";
 import CatMascot from "../../assets/UNSWipe-cat.png";
 import UNSWipeLogo from "../../assets/UNSWipe-logo-md.png";
 import { FormEvent, useContext, useRef, useState } from "react";
@@ -17,7 +17,6 @@ const LoginPage = () => {
   const [loginLoading, setLoginLoading] = useState<boolean>(false);
   const emailRef = useRef<HTMLInputElement>(null);
   const passwordRef = useRef<HTMLInputElement>(null);
-  const navigate = useNavigate()
 
   if (token) {
     return <Navigate to="/" />;

--- a/frontend/src/pages/register/RegisterPage.tsx
+++ b/frontend/src/pages/register/RegisterPage.tsx
@@ -5,27 +5,20 @@ import { FormEvent, useContext, useRef, useState } from "react";
 import ErrorModal from "../../components/ErrorModal";
 import { Spinner } from "react-bootstrap";
 import { AppContext } from "../../contexts/AppContext";
-import axios from "axios";
-import {
-  AUTH_PATH,
-  LOCAL_HOST,
-  LOGIN_PATH,
-  REGISTER_PATH,
-} from "../../utils/constants";
 import CatMascot from "../../assets/UNSWipe-cat.png";
 import UNSWipeLogo from "../../assets/UNSWipe-logo-md.png";
 import CustomButton from "../../components/CustomButton";
 
 const RegisterPage = () => {
-  const { token, updateToken } = useContext(AppContext);
+  const { token } = useContext(AppContext);
   const [errorMessage, setErrorMessage] = useState<string>("");
-  const [registerLoading, setRegisterLoading] = useState<boolean>(false);
+  const [registerLoading] = useState<boolean>(false);
   const firstNameRef = useRef<HTMLInputElement>(null);
   const lastNameRef = useRef<HTMLInputElement>(null);
   const emailRef = useRef<HTMLInputElement>(null);
   const passwordRef = useRef<HTMLInputElement>(null);
   const confirmPasswordRef = useRef<HTMLInputElement>(null);
-  const navigate = useNavigate()
+  const navigate = useNavigate();
 
   if (token) {
     return <Navigate to="/" />;
@@ -57,26 +50,11 @@ const RegisterPage = () => {
       setErrorMessage("Passwords do not match.");
       return;
     }
-
-    try {
-      setRegisterLoading(true);
-      await axios.post(LOCAL_HOST + AUTH_PATH + REGISTER_PATH, {
-        firstName,
-        lastName,
-        email,
-        password,
-      });
-      const response = await axios.post(LOCAL_HOST + AUTH_PATH + LOGIN_PATH, {
-        email,
-        password,
-      });
-      updateToken(response.data.token);
-      console.log(response);
-    } catch {
-      setErrorMessage("Failed to register.");
-    } finally {
-      setRegisterLoading(false);
-    }
+    localStorage.setItem("email", email);
+    localStorage.setItem("firstName", firstName);
+    localStorage.setItem("lastName", lastName);
+    localStorage.setItem("password", password);
+    navigate("/register/current-courses");
   };
 
   return (
@@ -95,17 +73,25 @@ const RegisterPage = () => {
               <Input
                 placeholder="first name"
                 type="text"
+                initialValue={localStorage.getItem("firstName") || ""}
                 forwardedRef={firstNameRef}
               />
               <Input
                 placeholder="last name"
                 type="text"
+                initialValue={localStorage.getItem("lastName") || ""}
                 forwardedRef={lastNameRef}
               />
-              <Input placeholder="email" type="text" forwardedRef={emailRef} />
+              <Input
+                placeholder="email"
+                type="text"
+                forwardedRef={emailRef}
+                initialValue={localStorage.getItem("email") || ""}
+              />
               <Input
                 placeholder="password"
                 type="password"
+                initialValue={localStorage.getItem("password") || ""}
                 forwardedRef={passwordRef}
               />
               <Input

--- a/frontend/src/utils/constants.ts
+++ b/frontend/src/utils/constants.ts
@@ -7,3 +7,31 @@ export const LOGIN_PATH = "login/";
 export const SUPER_PATH = "super/";
 export const USERS_PATH = "users/";
 export const SELF_PATH = "self/";
+
+export const COURSES_LIST = [
+  "COMP1511",
+  "COMP1521",
+  "COMP1531",
+  "COMP2521",
+  "COMP2511",
+  "COMP3121",
+  "COMP3821",
+  "COMP6080",
+  "COMP2041",
+  "COMP3231",
+  "COMP3141",
+  "COMP3311",
+  "COMP3331",
+  "COMP6441",
+  "COMP6771",
+  "COMP6841",
+  "COMP6991",
+  "COMP3900",
+  "COMP4200",
+  "COMP4128",
+  "MATH1081",
+  "MATH1131",
+  "MATH1231",
+  "MATH1241",
+  "MATH1141",
+];


### PR DESCRIPTION
- all user selection of current courses will be stored in local storage via the key `selectedCurrentCourses`
- **note: backend is designed such that a user can only register upon all data inputs have been given (e.g. cannot register with just email + name + password -> will need things like courses + hobbies + wam, etc) as @Chinosu has intended it to**
- user can navigate back to register page with the exception that they must re-confirm their original password again before proceeding to current page
- route to access this new feature is `/register/current-courses` 
- new route to use in the next upcoming ticket is to be setup `/register/future-courses`
- **note: these routes are not protected but they can be depending on whether we are bothered or not lol**