### PR TITLE
Minor backend deploy fixes

### DIFF
--- a/backend/add-js-extension.sh
+++ b/backend/add-js-extension.sh
@@ -4,7 +4,7 @@
 directory='./src'
 
 # Regex pattern to match JavaScript import statements that don't include ".js" at the end of the source path
-pattern="from ['\"](.+/[^'\"]*?)['\"]"
+pattern="from ['\"](\.+\/[^'\"]*?)['\"]"
 
 # Replacement pattern that adds ".js"
 replacement="from \"\1.js\""


### PR DESCRIPTION
Change regex pattern from `['\"](.+/[^'\"]*?)['\"]` to `['\"](\.+\/[^'\"]*?)['\"]`, which now ignores import statements that do not start with at least one dot followed by a slash

For example:
```
./xyz [YES]
.xyz [NO]
/xyz [NO]
../../xyz [YES]
```